### PR TITLE
fix: Big cpp program with too many symbol

### DIFF
--- a/script/shell_modify_variable_attach_parent.sh
+++ b/script/shell_modify_variable_attach_parent.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
 expect -c "
-  spawn gdb -q attach $1
+  set timeout 60000
+  spawn gdb -q -iex \"set pagination off\" attach $1
   expect {
     \"gdb\" {send \"set follow-fork-mode $2\n\";}
-  }
-  expect {
-    \"gdb\" {send \"set pagination off\n\";}
   }
   expect {
     \"gdb\" {send \"$3\n\";}
@@ -34,6 +32,9 @@ expect -c "
   }
   expect {
     \"gdb\" {send \"c\n\";}
+  }
+  expect {
+    \"exited\" {send \"quit\n\";}
   }
 
  interact


### PR DESCRIPTION
Fix program with too many symbols:
- Avoid default time of getting expect result. Add `set timeout 60000`
- Avoid setting pagination off not take effect. Set pagination off when gdb start.
- Avoid expect interact not take effect.Add expect response of program exist.